### PR TITLE
Small corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Generated files
+*.aux
+*.bbl
+*.blg
+*.idx
+*.log
+*.pdf
+*.toc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Standard ML. To build a PDF, perform the following steps in a terminal window:
 ```
 pdflatex root
 bibtex root
-peflatex root
+pdflatex root
 pdflatex root
 ```
 

--- a/mac.tex
+++ b/mac.tex
@@ -743,7 +743,7 @@
 \newcommand{\comments}{{\it Comments:\ }}
 \newcommand{\rulesec}[2]{\subsection*{{\bf#1}\hfill\fbox{$#2$}}}
 %
-\font\msxm=msxm10
+\font\msxm=msam10
 \textfont10=\msxm
 \mathchardef\restrict="0A16
 %


### PR DESCRIPTION
These 3 commits:
- Fix a typo in the `README.md`
- Add the generated output from running LaTeX to `.gitignore`.
- Replace the use of font `msxm10` with the use of `msam10`. This is supposedly the correct font to use on modern LaTeX-distributions, since the font `msxm10` typically isn't included anymore.
